### PR TITLE
resolve PsiPrimitiveType to DuckType

### DIFF
--- a/intellij-idea/src/main/kotlin/com/itangcent/intellij/psi/DefaultPsiClassHelper.kt
+++ b/intellij-idea/src/main/kotlin/com/itangcent/intellij/psi/DefaultPsiClassHelper.kt
@@ -196,7 +196,7 @@ open class DefaultPsiClassHelper : AbstractPsiClassHelper() {
                     val classWithFieldOrMethod =
                         psiResolver!!.resolveClassWithPropertyOrMethod(convertTo, enumClass)
                     if (classWithFieldOrMethod == null) {
-
+                        logger!!.error("failed to resolve:$convertTo")
                     } else {
                         val convertFieldOrMethod = classWithFieldOrMethod.second!!
                         if (convertFieldOrMethod is PsiField) {
@@ -238,9 +238,6 @@ open class DefaultPsiClassHelper : AbstractPsiClassHelper() {
                     if (resolveClass == null) {
                         logger!!.error("failed to resolve class:$convertTo")
                     } else {
-                        kv.safeComputeIfAbsent("@see") { KV.create<String, Any?>() }
-                        val see: KV<String, Any?> = kv["@see"] as KV<String, Any?>
-                        see[fieldName] = resolveClass.qualifiedName
                         super.parseFieldOrMethod(
                             fieldName,
                             jvmClassHelper.resolveClassToType(resolveClass)!!,
@@ -306,7 +303,7 @@ open class DefaultPsiClassHelper : AbstractPsiClassHelper() {
                     val classWithFieldOrMethod =
                         psiResolver!!.resolveClassWithPropertyOrMethod(convertTo, enumClass)
                     if (classWithFieldOrMethod == null) {
-
+                        logger!!.error("failed to resolve:$convertTo")
                     } else {
                         val convertFieldOrMethod = classWithFieldOrMethod.second!!
                         if (convertFieldOrMethod is PsiField) {
@@ -350,9 +347,6 @@ open class DefaultPsiClassHelper : AbstractPsiClassHelper() {
                     if (resolveClass == null) {
                         logger!!.error("failed to resolve class:$convertTo")
                     } else {
-                        kv.safeComputeIfAbsent("@see") { KV.create<String, Any?>() }
-                        val see: KV<String, Any?> = kv["@see"] as KV<String, Any?>
-                        see[fieldName] = resolveClass.qualifiedName
                         super.parseFieldOrMethod(
                             fieldName,
                             jvmClassHelper.resolveClassToType(resolveClass)!!,

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/DuckTypeHelper.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/DuckTypeHelper.kt
@@ -37,6 +37,10 @@ class DuckTypeHelper {
                 return lub.resolve()?.let { SingleDuckType(it) }
             }
         }
+
+        if (type is PsiPrimitiveType) {
+            return SinglePrimitiveDuckType(type)
+        }
         return null
 
     }
@@ -61,6 +65,10 @@ class DuckTypeHelper {
             }
         }
 
+
+        if (psiType is PsiPrimitiveType) {
+            return SinglePrimitiveDuckType(psiType)
+        }
         return null
     }
 

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/PsiClassHelper.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/PsiClassHelper.kt
@@ -35,9 +35,10 @@ interface PsiClassHelper {
 
     fun resolveEnumOrStatic(
         classNameWithProperty: String,
-        psiMember: PsiMember,
+        context: PsiElement,
         defaultPropertyName: String
     ): ArrayList<HashMap<String, Any?>>?
 
 
+    fun resolveEnumOrStatic(cls: PsiClass?, property: String?): ArrayList<HashMap<String, Any?>>?
 }

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/SinglePrimitiveDuckType.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/SinglePrimitiveDuckType.kt
@@ -1,0 +1,37 @@
+package com.itangcent.intellij.jvm
+
+import com.intellij.psi.PsiPrimitiveType
+
+class SinglePrimitiveDuckType : DuckType {
+
+    fun psiType(): PsiPrimitiveType {
+        return psiType
+    }
+
+    private val psiType: PsiPrimitiveType
+
+    constructor(psiType: PsiPrimitiveType) {
+        this.psiType = psiType
+    }
+
+    override fun toString(): String {
+        return psiType.toString()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SinglePrimitiveDuckType
+
+        if (psiType != other.psiType) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return psiType.hashCode()
+    }
+
+
+}

--- a/intellij-kotlin-support/src/main/kotlin/com/itangcent/intellij/jvm/kotlin/KotlinAnnotationHelper.kt
+++ b/intellij-kotlin-support/src/main/kotlin/com/itangcent/intellij/jvm/kotlin/KotlinAnnotationHelper.kt
@@ -14,8 +14,6 @@ import org.jetbrains.kotlin.asJava.elements.KtLightPsiLiteral
 import org.jetbrains.kotlin.idea.util.findAnnotation
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.plainContent
-import org.jetbrains.uast.getContainingClass
-
 
 /**
  * see https://kotlinlang.org/docs/reference/annotations.html
@@ -130,12 +128,11 @@ class KotlinAnnotationHelper : StandardAnnotationHelper() {
             return null
         }
 
-        val psiMember = when (psiElement) {
-            is PsiMember -> psiElement
-            else -> psiElement.getContainingClass()
-        } ?: return null
+        if (psiElement == null) {
+            return null
+        }
 
-        val resolveClass = psiResolver!!.resolveClass(annName, psiMember) ?: return null
+        val resolveClass = psiResolver!!.resolveClass(annName, psiElement) ?: return null
         if (resolveClass is KtLightClass) {
             val parameters = resolveClass.kotlinOrigin?.getPrimaryConstructorParameterList()?.parameters ?: return null
             if (parameters.size > index) {


### PR DESCRIPTION
- resolve PsiPrimitiveType to DuckType

- remove deprecated methods usages: UastUtils.getContainingClass()