### PR TITLE
feat: new rule `enum.use.name`&`enum.use.ordinal`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'kotlin'

--- a/guice-action/build.gradle
+++ b/guice-action/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'

--- a/intellij-idea/build.gradle
+++ b/intellij-idea/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'

--- a/intellij-idea/src/main/kotlin/com/itangcent/intellij/psi/ClassRuleKeys.kt
+++ b/intellij-idea/src/main/kotlin/com/itangcent/intellij/psi/ClassRuleKeys.kt
@@ -17,6 +17,18 @@ object ClassRuleKeys {
             BooleanRule::class, BooleanRuleMode.ANY
         )
 
+    val ENUM_USE_NAME: RuleKey<Boolean> =
+        SimpleRuleKey(
+            "enum.use.name",
+            BooleanRule::class, BooleanRuleMode.ANY
+        )
+
+    val ENUM_USE_ORDINAL: RuleKey<Boolean> =
+        SimpleRuleKey(
+            "enum.use.ordinal",
+            BooleanRule::class, BooleanRuleMode.ANY
+        )
+
     val FIELD_DOC: RuleKey<String> = SimpleRuleKey(
         "field.doc",
         arrayOf("doc.field"),

--- a/intellij-jvm/build.gradle
+++ b/intellij-jvm/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/JvmClassHelper.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/JvmClassHelper.kt
@@ -24,6 +24,12 @@ interface JvmClassHelper {
 
     fun isCollection(duckType: DuckType): Boolean
 
+    fun isString(psiClass: PsiClass): Boolean
+
+    fun isString(psiType: PsiType): Boolean
+
+    fun isString(duckType: DuckType): Boolean
+
     fun isPublicStaticFinal(field: PsiField): Boolean
 
     fun isNormalType(typeName: String): Boolean

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/PsiClassHelper.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/PsiClassHelper.kt
@@ -49,13 +49,16 @@ interface PsiClassHelper {
 
     @Deprecated(
         "use [com.itangcent.intellij.jvm.PsiClassHelper.resolveEnumOrStatic(com.intellij.psi.PsiClass, java.lang.String, java.lang.String)]",
-        ReplaceWith("resolveEnumOrStatic(cls, property, property ?: \"\")")
+        ReplaceWith("resolveEnumOrStatic(cls, property, property)")
     )
-    fun resolveEnumOrStatic(cls: PsiClass?, property: String?): ArrayList<HashMap<String, Any?>>? {
-        return resolveEnumOrStatic(cls, property, property ?: "")
+    fun resolveEnumOrStatic(
+        context: PsiElement, cls: PsiClass?, property: String?
+    ): ArrayList<HashMap<String, Any?>>? {
+        return resolveEnumOrStatic(context, cls, property, "")
     }
 
     fun resolveEnumOrStatic(
+        context: PsiElement,
         cls: PsiClass?, property: String?,
         defaultPropertyName: String
     ): ArrayList<HashMap<String, Any?>>?

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/PsiResolver.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/PsiResolver.kt
@@ -9,7 +9,8 @@ import com.itangcent.intellij.jvm.standard.StandardPsiResolver
 @ImplementedBy(StandardPsiResolver::class)
 interface PsiResolver {
 
-    @Deprecated(message = "will be removed next version",
+    @Deprecated(
+        message = "will be removed next version",
         replaceWith = ReplaceWith("com.itangcent.intellij.jvm.DuckTypeHelper.resolveClass")
     )
     fun resolveClass(className: String, psiElement: PsiElement): PsiClass?
@@ -38,6 +39,7 @@ interface PsiResolver {
      * {
      * params:{}
      * name:""
+     * ordinal:1
      * desc:""
      * }
      */

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/adapt/Property.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/adapt/Property.kt
@@ -1,0 +1,70 @@
+package com.itangcent.intellij.jvm.adapt
+
+import com.intellij.psi.*
+
+/**
+ * may be a field or a method.
+ */
+interface Property {
+
+    fun pis(): PsiElement
+
+    fun name(): String
+
+    fun type(): PsiType
+
+    companion object {
+        fun of(member: PsiMember): Property? {
+            return when (member) {
+                is PsiField -> FieldProperty(member)
+                is PsiMethod -> MethodProperty(member)
+                else -> null
+            }
+        }
+    }
+}
+
+class FieldProperty(private val field: PsiField) : Property {
+    override fun pis(): PsiElement {
+        return field
+    }
+
+    override fun name(): String {
+        return field.name
+    }
+
+    override fun type(): PsiType {
+        return field.type
+    }
+}
+
+class MethodProperty(private val method: PsiMethod) : Property {
+    override fun pis(): PsiElement {
+        return method
+    }
+
+    override fun name(): String {
+        return method.name.propertyName()
+    }
+
+    override fun type(): PsiType {
+        return method.returnType ?: PsiType.VOID
+    }
+}
+
+
+fun String.maybeMethodPropertyName(): Boolean {
+    return when {
+        this.startsWith("get") -> true
+        this.startsWith("is") -> true
+        else -> false
+    }
+}
+
+fun String.propertyName(): String {
+    return when {
+        this.startsWith("get") -> this.removePrefix("get")
+        this.startsWith("is") -> this.removePrefix("is")
+        else -> this
+    }.decapitalize().removeSuffix("()")
+}

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/standard/StandardJvmClassHelper.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/standard/StandardJvmClassHelper.kt
@@ -99,6 +99,18 @@ open class StandardJvmClassHelper : JvmClassHelper {
         return isInheritor(duckType, *mapClasses!!)
     }
 
+    override fun isString(psiClass: PsiClass): Boolean {
+        return stringClasses!!.contains(psiClass.qualifiedName)
+    }
+
+    override fun isString(psiType: PsiType): Boolean {
+        return stringClasses!!.contains(psiType.canonicalText)
+    }
+
+    override fun isString(duckType: DuckType): Boolean {
+        return stringClasses!!.contains(duckType.canonicalText())
+    }
+
     /**
      * Checks if the class is an enumeration.
      *
@@ -403,6 +415,7 @@ open class StandardJvmClassHelper : JvmClassHelper {
 
         var collectionClasses: Array<String>? = null
         var mapClasses: Array<String>? = null
+        var stringClasses: Array<String>? = null
 
         private val PRIMITIVE_TYPES = HashMap<String, PsiType>(9)
 
@@ -468,6 +481,9 @@ open class StandardJvmClassHelper : JvmClassHelper {
                 addClass(HashMap::class.java, mapClasses)
                 addClass(LinkedHashMap::class.java, mapClasses)
                 this.mapClasses = mapClasses.toTypedArray()
+            }
+            if (stringClasses == null) {
+                this.stringClasses = arrayOf("java.lang.String")
             }
 
             PRIMITIVE_TYPES[PsiType.VOID.canonicalText] = PsiType.VOID;

--- a/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/standard/StandardPsiResolver.kt
+++ b/intellij-jvm/src/main/kotlin/com/itangcent/intellij/jvm/standard/StandardPsiResolver.kt
@@ -200,30 +200,30 @@ open class StandardPsiResolver : PsiResolver {
         val parameters = construct?.parameterList?.parameters
         if (expressions != null && parameters != null && parameters.isNotEmpty()) {
             if (parameters.last().isVarArgs) {
-
-                for (index in 0 until parameters.size - 1) {
-                    params[parameters[index].name!!] = PsiUtils.resolveExpr(expressions[index])
+                for (i in 0 until parameters.size - 1) {
+                    params[parameters[i].name!!] = PsiUtils.resolveExpr(expressions[i])
                 }
                 try {
                     //resolve varArgs
                     val lastVarArgParam: ArrayList<Any?> = ArrayList(1)
                     params[parameters[parameters.size - 1].name!!] = lastVarArgParam
-                    for (index in parameters.size - 1..expressions.size) {
-                        lastVarArgParam.add(PsiUtils.resolveExpr(expressions[index]))
+                    for (i in parameters.size - 1..expressions.size) {
+                        lastVarArgParam.add(PsiUtils.resolveExpr(expressions[i]))
                     }
                 } catch (e: Throwable) {
                 }
-            }
-
-            for ((index, parameter) in parameters.withIndex()) {
-                try {
-                    params[parameter.name!!] = PsiUtils.resolveExpr(expressions[index])
-                } catch (e: Throwable) {
+            } else {
+                for ((i, parameter) in parameters.withIndex()) {
+                    try {
+                        params[parameter.name!!] = PsiUtils.resolveExpr(expressions[i])
+                    } catch (e: Throwable) {
+                    }
                 }
             }
         }
         constant["params"] = params
         constant["name"] = psiField.name
+        constant["ordinal"] = index
         constant["desc"] = docHelper!!.getAttrOfField(psiField)?.trim()
         return constant
     }

--- a/intellij-kotlin-support/build.gradle
+++ b/intellij-kotlin-support/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'

--- a/intellij-kotlin-support/src/main/kotlin/com/itangcent/intellij/jvm/kotlin/KotlinJvmClassHelper.kt
+++ b/intellij-kotlin-support/src/main/kotlin/com/itangcent/intellij/jvm/kotlin/KotlinJvmClassHelper.kt
@@ -49,6 +49,18 @@ class KotlinJvmClassHelper(val jvmClassHelper: JvmClassHelper) : JvmClassHelper 
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
+    override fun isString(psiClass: PsiClass): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isString(psiType: PsiType): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isString(duckType: DuckType): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
     override fun isPublicStaticFinal(field: PsiField): Boolean {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
@@ -300,6 +312,9 @@ class KotlinJvmClassHelper(val jvmClassHelper: JvmClassHelper) : JvmClassHelper 
             addClass(MutableMap::class, mapClasses)
             StandardJvmClassHelper.mapClasses = mapClasses.toTypedArray()
 
+            val stringClasses = Sets.newHashSet(*StandardJvmClassHelper.stringClasses!!)
+            addClass(String::class, stringClasses)
+            StandardJvmClassHelper.stringClasses = stringClasses.toTypedArray()
         }
 
         private fun addClass(cls: KClass<*>, classSet: HashSet<String>) {

--- a/intellij-scala-support/build.gradle
+++ b/intellij-scala-support/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'com.itangcent'
-version '0.7.8-SNAPSHOT'
+version '0.7.9-SNAPSHOT'
 
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'

--- a/intellij-scala-support/src/main/kotlin/com/itangcent/intellij/jvm/scala/ScalaJvmClassHelper.kt
+++ b/intellij-scala-support/src/main/kotlin/com/itangcent/intellij/jvm/scala/ScalaJvmClassHelper.kt
@@ -1,5 +1,6 @@
 package com.itangcent.intellij.jvm.scala
 
+import com.google.common.collect.Sets
 import com.intellij.lang.jvm.JvmParameter
 import com.intellij.psi.*
 import com.itangcent.common.utils.getPropertyValue
@@ -10,6 +11,7 @@ import com.itangcent.intellij.jvm.scala.adaptor.ScPatternDefinitionPsiFieldAdapt
 import com.itangcent.intellij.jvm.scala.adaptor.ScalaPsiFieldAdaptor
 import com.itangcent.intellij.jvm.scala.adaptor.ScalaTypeParameterType2PsiTypeParameterAdaptor
 import com.itangcent.intellij.jvm.scala.compatible.ScCompatiblePhysicalMethodSignature
+import com.itangcent.intellij.jvm.standard.StandardJvmClassHelper
 import com.itangcent.intellij.jvm.standard.StandardJvmClassHelper.Companion.normalTypes
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScPatternDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScVariable
@@ -50,6 +52,18 @@ class ScalaJvmClassHelper(val jvmClassHelper: JvmClassHelper) : JvmClassHelper {
     }
 
     override fun isCollection(psiType: PsiType): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isString(psiClass: PsiClass): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isString(psiType: PsiType): Boolean {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun isString(duckType: DuckType): Boolean {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
@@ -342,6 +356,10 @@ class ScalaJvmClassHelper(val jvmClassHelper: JvmClassHelper) : JvmClassHelper {
             normalTypes["Null"] = null
             normalTypes["Unit"] = null
             normalTypes["_root_.scala.Predef.String"] = ""
+
+            val stringClasses = Sets.newHashSet(*StandardJvmClassHelper.stringClasses!!)
+            stringClasses.add("_root_.scala.Predef.String")
+            StandardJvmClassHelper.stringClasses = stringClasses.toTypedArray()
         }
     }
 

--- a/intellij-scala-support/src/main/kotlin/com/itangcent/intellij/jvm/scala/ScalaPsiResolver.kt
+++ b/intellij-scala-support/src/main/kotlin/com/itangcent/intellij/jvm/scala/ScalaPsiResolver.kt
@@ -71,20 +71,21 @@ open class ScalaPsiResolver : StandardPsiResolver() {
                     if (exprs.size() == 2) {
                         var id: Int = index
                         var name: String? = null
-                        var index = 0
+                        var i = 0
                         for (ex in exprs) {
                             val value = ScPsiUtils.valueOf(ex)
-                            if (index == 0) {
+                            if (i == 0) {
                                 id = value.asInt() ?: 0
                             } else {
                                 name = value.toString()
                                 break
                             }
-                            index++
+                            i++
                         }
 
                         return KV.create<String, Any?>()
                             .set("name", name ?: psiField.name)
+                            .set("ordinal", index)
                             .set("desc", attrOfField)
                             .set(
                                 "params", KV.create<String, Any>()
@@ -97,6 +98,7 @@ open class ScalaPsiResolver : StandardPsiResolver() {
                         if (value is Int) {
                             return KV.create<String, Any?>()
                                 .set("name", psiField.name)
+                                .set("ordinal", index)
                                 .set("desc", attrOfField)
                                 .set(
                                     "params", KV.create<String, Any>()
@@ -106,6 +108,7 @@ open class ScalaPsiResolver : StandardPsiResolver() {
                         } else if (value is String) {
                             return KV.create<String, Any?>()
                                 .set("name", psiField.name)
+                                .set("ordinal", index)
                                 .set("desc", attrOfField)
                                 .set(
                                     "params", KV.create<String, Any>()


### PR DESCRIPTION
fix tangcent/easy-yapi#248

---

## demo

```java

enum class AsynchronousTaskStatusEnum(private var value: String) : BaseEnum {
    /**
     * 初始化
     */
    INITIALIZATION("初始化"),

    /**
     * 成功
     */
    SUCCESS("成功"),

    /**
     * 失败
     */
    FAILURE("失败");

    override fun getKey(): String {
        return name
    }

    override fun getValue(): String {
        return value
    }
}
```

```java

class Task {
    /**
     * 任务状态
     *
     * @see AsynchronousTaskStatusEnum
     */
    var taskStatus: String? = null

    /**
     * 任务状态int
     *
     * @see AsynchronousTaskStatusEnum
     */
    var taskStatusInt: Int? = 0
}
```

*default desc* 

| name  |  type  |  desc  |
| ------------ | ------------ | ------------ |
| taskStatus | string | 任务状态 |
| taskStatusInt | integer | 任务状态int |

*config:*
```properties
enum.use.name=groovy:it.type().name()=="java.lang.String"
enum.use.ordinal=groovy:it.type().name()=="int"
enum.use.ordinal=groovy:it.type().name()=="java.lang.Integer"
```
*with config:*

| name  |  type  |  desc  |
| ------------ | ------------ | ------------ |
| taskStatus | string | 任务状态<br>INITIALIZATION :初始化<br>SUCCESS :成功<br>FAILURE :失败 |
| taskStatusInt | integer | 任务状态int<br>1 :初始化<br>2 :成功<br>3 :失败 |
 
