### PR TITLE
feat: remove deprecated constructor NotificationGroup(*)

### DIFF
--- a/guice-action/src/main/kotlin/com/itangcent/intellij/logger/DefaultNotificationHelper.kt
+++ b/guice-action/src/main/kotlin/com/itangcent/intellij/logger/DefaultNotificationHelper.kt
@@ -8,6 +8,7 @@ import com.intellij.notification.NotificationDisplayType
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.Notifications
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowId
 
 @Singleton
 class DefaultNotificationHelper : NotificationHelper {
@@ -28,7 +29,15 @@ class DefaultNotificationHelper : NotificationHelper {
     @Synchronized
     fun getNotificationGroup(): NotificationGroup {
         if (notificationGroup == null) {
-            notificationGroup = NotificationGroup("${pluginName}_NotificationGroup", notificationDisplayType, true)
+            val notificationId = "${pluginName}_Notification"
+            notificationGroup = when (notificationDisplayType) {
+                NotificationDisplayType.BALLOON ->
+                    NotificationGroup.balloonGroup(notificationId)
+                NotificationDisplayType.TOOL_WINDOW ->
+                    NotificationGroup.toolWindowGroup(notificationId, ToolWindowId.RUN, true)
+                else ->
+                    NotificationGroup.logOnlyGroup(notificationId)
+            }
         }
         return notificationGroup!!
     }


### PR DESCRIPTION
## Scheduled for removal constructor usage
Deprecated constructor NotificationGroup.<init>(...) is invoked in DefaultNotificationHelper.getNotificationGroup().
This constructor will be removed in 2021.3