### PR TITLE
fix: Ensure 'SelectedHelper' processes navigation only once

### DIFF
--- a/intellij-idea/src/main/kotlin/com/itangcent/intellij/psi/SelectedHelper.kt
+++ b/intellij-idea/src/main/kotlin/com/itangcent/intellij/psi/SelectedHelper.kt
@@ -72,6 +72,7 @@ object SelectedHelper {
             //try to process navigatables
             if (!navigatables.isNullOrEmpty()) {
                 onNavigatables(navigatables)
+                return
             }
 
             //try to get navigatable


### PR DESCRIPTION
fix tangcent/easy-yapi#1085